### PR TITLE
Fix exception on empty inputs

### DIFF
--- a/autoCastPatch.py
+++ b/autoCastPatch.py
@@ -271,6 +271,10 @@ def map_node_over_list(obj, input_data_all, func, allow_interrupt=False):
 
     # node_inputs = {input_name: (input_type, {default: foo,})}
     for input_name, config in node_inputs.items():
+        # if input_name is not included (empty) just skip it
+        if input_name not in input_data_all:             
+            continue
+
         # for each input, typecast/clamp the incoming values.
         match config[0]:
             case "FLOAT" | "NUMBER":


### PR DESCRIPTION
- Skip inputs not included in input_data_all instead of throwing exception

Before:
![image](https://github.com/GMapeSplat/ComfyUI_ezXY/assets/18334824/e708c5fe-feb7-4e61-a456-d81cfb799064)

After:
<img width="936" alt="image" src="https://github.com/GMapeSplat/ComfyUI_ezXY/assets/18334824/c557f016-a6c1-4059-b3d7-15cb094c63ea">

